### PR TITLE
fix(git-protocol): frame receive-pack bodies by pkt-line structure

### DIFF
--- a/ceres/src/application/api_service/mono/sync.rs
+++ b/ceres/src/application/api_service/mono/sync.rs
@@ -207,9 +207,12 @@ impl MonoApiService {
             .git_receive_pack_stream(
                 &state,
                 commands,
-                into_pack_byte_stream(tokio_stream::once(Ok::<Bytes, std::convert::Infallible>(
+                Some(into_pack_byte_stream(tokio_stream::once(Ok::<
+                    Bytes,
+                    std::convert::Infallible,
+                >(
                     Bytes::from(pack_data),
-                ))),
+                )))),
             )
             .await
             .map_err(|e| MegaError::Other(format!("{e}")))?;

--- a/ceres/src/application/code_edit/post_receive/import.rs
+++ b/ceres/src/application/code_edit/post_receive/import.rs
@@ -109,9 +109,17 @@ pub async fn dispatch_import_receive_pack_finalized(
                         .await?;
                 }
                 CommandType::Delete => {
-                    git_db
-                        .remove_ref_in_txn(repo_id, &cmd.ref_name, &txn)
-                        .await?;
+                    // Same lease rule as deletion-only pushes: never remove a
+                    // ref that moved after ref discovery.
+                    if !git_db
+                        .remove_ref_if_unchanged(repo_id, &cmd.ref_name, &cmd.old_id, &txn)
+                        .await?
+                    {
+                        return Err(MegaError::Other(format!(
+                            "ref {} moved since advertisement (expected {})",
+                            cmd.ref_name, cmd.old_id
+                        )));
+                    }
                 }
                 CommandType::Update => {
                     git_db
@@ -218,23 +226,17 @@ async fn apply_branch_deletions(
     let txn = storage.begin_db_transaction().await?;
     let git_db = storage.git_db_storage();
     for &cmd in deletions {
-        // Compare-and-delete within the transaction: the advertised old id is
-        // the client's lease on the ref. Another push may have advanced the
-        // branch after ref discovery, and deleting by name alone would remove
-        // that newer tip.
-        let current = git_db
-            .get_ref_by_name_in_txn(repo_id, &cmd.ref_name, &txn)
+        // The advertised old id is the client's lease on the ref; a
+        // conditional delete keeps the check atomic against concurrent pushes.
+        if !git_db
+            .remove_ref_if_unchanged(repo_id, &cmd.ref_name, &cmd.old_id, &txn)
             .await?
-            .ok_or_else(|| MegaError::Other(format!("ref {} not found", cmd.ref_name)))?;
-        if current.ref_git_id != cmd.old_id {
+        {
             return Err(MegaError::Other(format!(
-                "ref {} moved since advertisement (expected {}, found {})",
-                cmd.ref_name, cmd.old_id, current.ref_git_id
+                "ref {} moved since advertisement (expected {})",
+                cmd.ref_name, cmd.old_id
             )));
         }
-        git_db
-            .remove_ref_in_txn(repo_id, &cmd.ref_name, &txn)
-            .await?;
     }
     txn.commit().await.map_err(MegaError::Db)
 }

--- a/ceres/src/application/code_edit/post_receive/import.rs
+++ b/ceres/src/application/code_edit/post_receive/import.rs
@@ -28,9 +28,25 @@ pub async fn dispatch_import_receive_pack_finalized(
     unpack_redlock: Arc<RedLock>,
     extra_timings: Arc<Mutex<Vec<(String, u128)>>>,
 ) -> Result<(), MegaError> {
-    let commit_id = match commands.iter().find(|c| c.ref_type == RefTypeEnum::Branch) {
+    // The attach commit is sourced from the pushed branch tip; deletions carry
+    // the zero id and resolve no commit. A push whose branch commands are all
+    // deletions has no content to attach (the repo is necessarily attached
+    // already, or its refs would not exist), so just apply the deletions.
+    let branch_cmds: Vec<&RefCommand> = commands
+        .iter()
+        .filter(|c| c.ref_type == RefTypeEnum::Branch)
+        .collect();
+    let attach_source = branch_cmds
+        .iter()
+        .find(|c| c.command_type != CommandType::Delete);
+    let commit_id = match attach_source {
         Some(cmd) => cmd.new_id.clone(),
-        None => return Ok(()),
+        None => {
+            if branch_cmds.is_empty() {
+                return Ok(());
+            }
+            return apply_branch_deletions(&storage, repo_id, &branch_cmds).await;
+        }
     };
 
     let mono_storage = storage.mono_storage();
@@ -191,4 +207,21 @@ pub async fn dispatch_import_receive_pack_finalized(
     Err(MegaError::Other(
         "attach_to_monorepo_parent: exceeded retry limit for concurrent root updates".into(),
     ))
+}
+
+/// Applies deletion-only branch commands. The monorepo root ref is untouched,
+/// so the root update lock and attach-retry loop are not needed.
+async fn apply_branch_deletions(
+    storage: &Storage,
+    repo_id: i64,
+    deletions: &[&RefCommand],
+) -> Result<(), MegaError> {
+    let txn = storage.begin_db_transaction().await?;
+    let git_db = storage.git_db_storage();
+    for cmd in deletions {
+        git_db
+            .remove_ref_in_txn(repo_id, &cmd.ref_name, &txn)
+            .await?;
+    }
+    txn.commit().await.map_err(MegaError::Db)
 }

--- a/ceres/src/application/code_edit/post_receive/import.rs
+++ b/ceres/src/application/code_edit/post_receive/import.rs
@@ -28,6 +28,28 @@ pub async fn dispatch_import_receive_pack_finalized(
     unpack_redlock: Arc<RedLock>,
     extra_timings: Arc<Mutex<Vec<(String, u128)>>>,
 ) -> Result<(), MegaError> {
+    // Deleting the current default branch would leave the repository with a
+    // dangling HEAD: ref discovery advertises a zero id and import APIs unwrap
+    // the now-missing default ref. Reject it for every path (deletion-only and
+    // mixed pushes alike) before any ref row is removed.
+    if let Some(default_ref) = storage
+        .git_db_storage()
+        .get_ref(repo_id)
+        .await?
+        .into_iter()
+        .find(|r| r.default_branch)
+        && commands.iter().any(|c| {
+            c.ref_type == RefTypeEnum::Branch
+                && c.command_type == CommandType::Delete
+                && c.ref_name == default_ref.ref_name
+        })
+    {
+        return Err(MegaError::Other(format!(
+            "cannot delete the current default branch {}",
+            default_ref.ref_name
+        )));
+    }
+
     // The attach commit is sourced from the pushed branch tip; deletions carry
     // the zero id and resolve no commit. A push whose branch commands are all
     // deletions has no content to attach (the repo is necessarily attached

--- a/ceres/src/application/code_edit/post_receive/import.rs
+++ b/ceres/src/application/code_edit/post_receive/import.rs
@@ -32,9 +32,11 @@ pub async fn dispatch_import_receive_pack_finalized(
     // the zero id and resolve no commit. A push whose branch commands are all
     // deletions has no content to attach (the repo is necessarily attached
     // already, or its refs would not exist), so just apply the deletions.
+    // Commands already rejected by the protocol layer keep their ng status and
+    // are excluded here; their report lines were already emitted upstream.
     let branch_cmds: Vec<&RefCommand> = commands
         .iter()
-        .filter(|c| c.ref_type == RefTypeEnum::Branch)
+        .filter(|c| c.ref_type == RefTypeEnum::Branch && c.status == "ok")
         .collect();
     let attach_source = branch_cmds
         .iter()
@@ -99,10 +101,7 @@ pub async fn dispatch_import_receive_pack_finalized(
 
         let txn = storage.begin_db_transaction().await?;
         let git_db = storage.git_db_storage();
-        for cmd in &commands {
-            if cmd.ref_type != RefTypeEnum::Branch {
-                continue;
-            }
+        for &cmd in &branch_cmds {
             match cmd.command_type {
                 CommandType::Create => {
                     git_db

--- a/ceres/src/application/code_edit/post_receive/import.rs
+++ b/ceres/src/application/code_edit/post_receive/import.rs
@@ -217,7 +217,21 @@ async fn apply_branch_deletions(
 ) -> Result<(), MegaError> {
     let txn = storage.begin_db_transaction().await?;
     let git_db = storage.git_db_storage();
-    for cmd in deletions {
+    for &cmd in deletions {
+        // Compare-and-delete within the transaction: the advertised old id is
+        // the client's lease on the ref. Another push may have advanced the
+        // branch after ref discovery, and deleting by name alone would remove
+        // that newer tip.
+        let current = git_db
+            .get_ref_by_name_in_txn(repo_id, &cmd.ref_name, &txn)
+            .await?
+            .ok_or_else(|| MegaError::Other(format!("ref {} not found", cmd.ref_name)))?;
+        if current.ref_git_id != cmd.old_id {
+            return Err(MegaError::Other(format!(
+                "ref {} moved since advertisement (expected {}, found {})",
+                cmd.ref_name, cmd.old_id, current.ref_git_id
+            )));
+        }
         git_db
             .remove_ref_in_txn(repo_id, &cmd.ref_name, &txn)
             .await?;

--- a/ceres/src/application/code_edit/post_receive/import.rs
+++ b/ceres/src/application/code_edit/post_receive/import.rs
@@ -28,28 +28,6 @@ pub async fn dispatch_import_receive_pack_finalized(
     unpack_redlock: Arc<RedLock>,
     extra_timings: Arc<Mutex<Vec<(String, u128)>>>,
 ) -> Result<(), MegaError> {
-    // Deleting the current default branch would leave the repository with a
-    // dangling HEAD: ref discovery advertises a zero id and import APIs unwrap
-    // the now-missing default ref. Reject it for every path (deletion-only and
-    // mixed pushes alike) before any ref row is removed.
-    if let Some(default_ref) = storage
-        .git_db_storage()
-        .get_ref(repo_id)
-        .await?
-        .into_iter()
-        .find(|r| r.default_branch)
-        && commands.iter().any(|c| {
-            c.ref_type == RefTypeEnum::Branch
-                && c.command_type == CommandType::Delete
-                && c.ref_name == default_ref.ref_name
-        })
-    {
-        return Err(MegaError::Other(format!(
-            "cannot delete the current default branch {}",
-            default_ref.ref_name
-        )));
-    }
-
     // The attach commit is sourced from the pushed branch tip; deletions carry
     // the zero id and resolve no commit. A push whose branch commands are all
     // deletions has no content to attach (the repo is necessarily attached

--- a/ceres/src/transport/pack/import_repo.rs
+++ b/ceres/src/transport/pack/import_repo.rs
@@ -401,6 +401,15 @@ impl RepoHandler for ImportRepo {
             .is_some()
     }
 
+    async fn check_tag_exist(&self, hash: &str) -> bool {
+        self.storage
+            .git_db_storage()
+            .get_tag_by_hash(self.repo.repo_id, hash)
+            .await
+            .unwrap()
+            .is_some()
+    }
+
     async fn check_default_branch(&self) -> bool {
         let storage = self.storage.git_db_storage();
         storage

--- a/ceres/src/transport/pack/import_repo.rs
+++ b/ceres/src/transport/pack/import_repo.rs
@@ -401,13 +401,32 @@ impl RepoHandler for ImportRepo {
             .is_some()
     }
 
-    async fn check_tag_exist(&self, hash: &str) -> bool {
-        self.storage
-            .git_db_storage()
+    /// A pushed tag may reference an annotated tag object, commit, tree, or
+    /// blob; accept it only if that object is stored.
+    async fn check_object_exist(&self, hash: &str) -> bool {
+        let git_db = self.storage.git_db_storage();
+        if git_db
             .get_tag_by_hash(self.repo.repo_id, hash)
             .await
             .unwrap()
             .is_some()
+            || self.check_commit_exist(hash).await
+        {
+            return true;
+        }
+        if git_db
+            .get_tree_by_hash(self.repo.repo_id, hash)
+            .await
+            .unwrap()
+            .is_some()
+        {
+            return true;
+        }
+        !git_db
+            .get_blobs_by_hashes(self.repo.repo_id, vec![hash.to_string()])
+            .await
+            .unwrap()
+            .is_empty()
     }
 
     async fn check_default_branch(&self) -> bool {

--- a/ceres/src/transport/pack/import_repo.rs
+++ b/ceres/src/transport/pack/import_repo.rs
@@ -404,7 +404,11 @@ impl RepoHandler for ImportRepo {
                 .lock()
                 .expect("command_list lock poisoned");
             cmds.iter()
-                .find(|c| c.ref_type == RefTypeEnum::Branch && c.new_id != ZERO_ID)
+                .find(|c| {
+                    c.ref_type == RefTypeEnum::Branch
+                        && c.status == "ok"
+                        && c.new_id != ZERO_ID
+                })
                 .map(|c| c.new_id.clone())
         };
         let current_head = match from_commands {

--- a/ceres/src/transport/pack/import_repo.rs
+++ b/ceres/src/transport/pack/import_repo.rs
@@ -27,7 +27,7 @@ use io_orbit::object_storage::MultiObjectByteStream;
 use jupiter::{
     redis::lock::RedLock,
     service::git_service::GitService,
-    storage::{Storage, git_db_storage::GitDbStorage},
+    storage::{Storage, base_storage::StorageConnector, git_db_storage::GitDbStorage},
     utils::converter::FromGitModel,
 };
 use tokio::sync::mpsc::{self, Sender};
@@ -363,10 +363,25 @@ impl RepoHandler for ImportRepo {
                     .await
                     .map_err(|e| GitError::CustomError(e.to_string()))?;
             }
-            CommandType::Delete => storage
-                .remove_ref(self.repo.repo_id, &refs.ref_name)
-                .await
-                .map_err(|e| GitError::CustomError(e.to_string()))?,
+            CommandType::Delete => {
+                // The advertised old id is the client's lease; a stale request
+                // must not remove a tag that moved after ref discovery.
+                if !storage
+                    .remove_ref_if_unchanged(
+                        self.repo.repo_id,
+                        &refs.ref_name,
+                        &refs.old_id,
+                        storage.get_connection(),
+                    )
+                    .await
+                    .map_err(|e| GitError::CustomError(e.to_string()))?
+                {
+                    return Err(GitError::CustomError(format!(
+                        "tag {} moved since advertisement (expected {})",
+                        refs.ref_name, refs.old_id
+                    )));
+                }
+            }
             CommandType::Update => {
                 storage
                     .update_ref(self.repo.repo_id, &refs.ref_name, &refs.new_id)

--- a/ceres/src/transport/pack/mod.rs
+++ b/ceres/src/transport/pack/mod.rs
@@ -234,6 +234,13 @@ pub trait RepoHandler: Send + Sync + 'static {
 
     async fn check_commit_exist(&self, hash: &str) -> bool;
 
+    /// Whether the repository stores an annotated tag object with this id.
+    /// Defaults to false so repo types that do not track tag objects reject
+    /// unverifiable tag targets instead of accepting them blind.
+    async fn check_tag_exist(&self, _hash: &str) -> bool {
+        false
+    }
+
     async fn check_default_branch(&self) -> bool;
 
     fn find_head_hash(&self, refs: Vec<Refs>) -> (String, Vec<Refs>) {

--- a/ceres/src/transport/pack/mod.rs
+++ b/ceres/src/transport/pack/mod.rs
@@ -234,12 +234,10 @@ pub trait RepoHandler: Send + Sync + 'static {
 
     async fn check_commit_exist(&self, hash: &str) -> bool;
 
-    /// Whether the repository stores an annotated tag object with this id.
-    /// Defaults to false so repo types that do not track tag objects reject
-    /// unverifiable tag targets instead of accepting them blind.
-    async fn check_tag_exist(&self, _hash: &str) -> bool {
-        false
-    }
+    /// Whether the repository stores any object with this id (tag, commit,
+    /// tree, or blob) that a pushed lightweight or annotated tag could
+    /// reference.
+    async fn check_object_exist(&self, hash: &str) -> bool;
 
     async fn check_default_branch(&self) -> bool;
 

--- a/ceres/src/transport/pack/monorepo.rs
+++ b/ceres/src/transport/pack/monorepo.rs
@@ -441,6 +441,13 @@ impl RepoHandler for MonoRepo {
             .is_some()
     }
 
+    // Tag pushes are rejected up front on the monorepo path, so this is only
+    // reachable for non-tag targets in practice; commits are the realistic
+    // reference target.
+    async fn check_object_exist(&self, hash: &str) -> bool {
+        self.check_commit_exist(hash).await
+    }
+
     async fn check_default_branch(&self) -> bool {
         true
     }

--- a/ceres/src/transport/pack/monorepo.rs
+++ b/ceres/src/transport/pack/monorepo.rs
@@ -39,7 +39,7 @@ use crate::{
     infra::cache::GitObjectCache,
     transport::{
         pack::RepoHandler,
-        protocol::import_refs::{RefCommand, Refs},
+        protocol::import_refs::{CommandType, RefCommand, Refs},
     },
 };
 
@@ -479,7 +479,7 @@ impl MonoRepo {
             .clone();
         let txn = self.storage.begin_db_transaction().await?;
         for cmd in &cmds {
-            if cmd.ref_type == RefTypeEnum::Branch {
+            if cmd.ref_type == RefTypeEnum::Branch && cmd.command_type != CommandType::Delete {
                 self.apply_cl_mega_ref_for_push_command(cmd, Some(&txn))
                     .await?;
             }

--- a/ceres/src/transport/pack/monorepo.rs
+++ b/ceres/src/transport/pack/monorepo.rs
@@ -43,13 +43,20 @@ use crate::{
     },
 };
 
+/// Branch-tip metadata describing the surviving work of this push. Behind a
+/// mutex because the protocol layer refines it after up-front rejections
+/// (deletions, missing targets) via [`RepoHandler::sync_commands_after_unpack`].
+pub struct BranchTip {
+    pub base_branch: String,
+    pub from_hash: String,
+    pub to_hash: String,
+}
+
 pub struct MonoRepo {
     pub storage: Storage,
     pub git_object_cache: Arc<GitObjectCache>,
     pub path: PathBuf,
-    pub base_branch: String,
-    pub from_hash: String,
-    pub to_hash: String,
+    pub tip: Mutex<BranchTip>,
     // current_commit only exists when an unpack operation occurs.
     // When only a branch is updated and the pack file is empty, this value will be None.
     pub current_commit: Arc<RwLock<Option<Commit>>>,
@@ -75,6 +82,26 @@ impl RepoHandler for MonoRepo {
             .command_list
             .lock()
             .expect("command_list lock poisoned") = commands.to_vec();
+        // Tip metadata was captured at handler construction, before the
+        // protocol layer rejected commands (deletions, missing targets); keep
+        // it pointing at surviving work so finalize events stay valid.
+        if let Some(command) = commands
+            .iter()
+            .find(|x| {
+                x.ref_type == RefTypeEnum::Branch
+                    && x.command_type != CommandType::Delete
+                    && x.status == "ok"
+            })
+        {
+            let mut tip = self.tip.lock().expect("branch tip lock poisoned");
+            tip.from_hash = command.old_id.clone();
+            tip.to_hash = command.new_id.clone();
+            tip.base_branch = command
+                .ref_name
+                .strip_prefix("refs/heads/")
+                .unwrap_or(command.ref_name.as_str())
+                .to_string();
+        }
     }
 
     async fn refs_with_head_hash(&self) -> (String, Vec<Refs>) {
@@ -162,15 +189,23 @@ impl RepoHandler for MonoRepo {
     }
 
     async fn finalize_receive_pack(&self) -> Result<(), MegaError> {
+        let (base_branch, from_hash, to_hash) = {
+            let tip = self.tip.lock().expect("branch tip lock poisoned");
+            (
+                tip.base_branch.clone(),
+                tip.from_hash.clone(),
+                tip.to_hash.clone(),
+            )
+        };
         self.persist_mono_branch_cl_mega_refs_transaction().await?;
         self.traverses_tree_and_update_filepath().await?;
         let cl_link = self.cl_link.read().await.clone();
         self.application
             .handle(TransportEvent::MonoReceivePackFinalized {
                 repo_path: self.path.clone(),
-                base_branch: self.base_branch.clone(),
-                from_hash: self.from_hash.clone(),
-                to_hash: self.to_hash.clone(),
+                base_branch,
+                from_hash,
+                to_hash,
                 username: self.username.clone(),
                 cl_link,
             })
@@ -479,7 +514,10 @@ impl MonoRepo {
             .clone();
         let txn = self.storage.begin_db_transaction().await?;
         for cmd in &cmds {
-            if cmd.ref_type == RefTypeEnum::Branch && cmd.command_type != CommandType::Delete {
+            if cmd.ref_type == RefTypeEnum::Branch
+                && cmd.status == "ok"
+                && cmd.command_type != CommandType::Delete
+            {
                 self.apply_cl_mega_ref_for_push_command(cmd, Some(&txn))
                     .await?;
             }

--- a/ceres/src/transport/protocol/mod.rs
+++ b/ceres/src/transport/protocol/mod.rs
@@ -11,7 +11,7 @@ use common::{
     errors::{MegaError, ProtocolError},
     utils::nested_import_repo_conflict_message,
 };
-use import_refs::RefCommand;
+use import_refs::{CommandType, RefCommand};
 use jupiter::redis::lock::RedLock;
 use repo::Repo;
 use tokio::sync::RwLock;
@@ -201,6 +201,28 @@ impl SmartSession {
                 }
             };
 
+            // Deleting the current default branch would leave the repository
+            // with a dangling HEAD: ref discovery advertises a zero id and
+            // import APIs unwrap the now-missing default ref. Reject before
+            // any persistence (tags included) happens.
+            if let Some(default_ref) = storage
+                .get_ref(repo.repo_id)
+                .await
+                .map_err(|e| ProtocolError::InvalidInput(format!("failed to load refs: {e}")))?
+                .into_iter()
+                .find(|r| r.default_branch)
+                && commands.iter().any(|c| {
+                    c.ref_type == RefTypeEnum::Branch
+                        && c.command_type == CommandType::Delete
+                        && c.ref_name == default_ref.ref_name
+                })
+            {
+                return Err(ProtocolError::InvalidInput(format!(
+                    "cannot delete the current default branch {}",
+                    default_ref.ref_name
+                )));
+            }
+
             let unpack_redlock = Arc::new(RedLock::new(
                 state.git_object_cache.connection.clone(),
                 // Serialize monorepo root mega_refs update across concurrent import attaches.
@@ -231,7 +253,13 @@ impl SmartSession {
                 username: self.auth.username.clone(),
                 command_list: Mutex::new(commands.clone()),
             };
-            if let Some(command) = commands.iter().find(|x| x.ref_type == RefTypeEnum::Branch) {
+            // Metadata must describe a surviving change: a deletion's zero
+            // new_id would otherwise flow into finalize events even when the
+            // deletion itself is rejected and other updates land.
+            if let Some(command) = commands
+                .iter()
+                .find(|x| x.ref_type == RefTypeEnum::Branch && x.command_type != CommandType::Delete)
+            {
                 res.from_hash = command.old_id.clone();
                 res.to_hash = command.new_id.clone();
                 res.base_branch = command

--- a/ceres/src/transport/protocol/mod.rs
+++ b/ceres/src/transport/protocol/mod.rs
@@ -18,7 +18,9 @@ use tokio::sync::RwLock;
 
 use crate::{
     bus::TransportRuntime,
-    transport::pack::{RepoHandler, import_repo::ImportRepo, monorepo::MonoRepo},
+    transport::pack::{
+        RepoHandler, import_repo::ImportRepo, monorepo::{BranchTip, MonoRepo},
+    },
 };
 
 pub mod import_refs;
@@ -240,34 +242,37 @@ impl SmartSession {
                 receive_pack_extra_timings_ms: Mutex::new(Vec::new()),
             }) as Arc<dyn RepoHandler>)
         } else {
-            let mut res = MonoRepo {
+            // Metadata must describe a surviving change: a deletion's zero
+            // new_id would otherwise flow into finalize events even when the
+            // deletion itself is rejected and other updates land.
+            let tip = commands
+                .iter()
+                .find(|x| x.ref_type == RefTypeEnum::Branch && x.command_type != CommandType::Delete)
+                .map(|command| BranchTip {
+                    base_branch: command
+                        .ref_name
+                        .strip_prefix("refs/heads/")
+                        .unwrap_or(command.ref_name.as_str())
+                        .to_string(),
+                    from_hash: command.old_id.clone(),
+                    to_hash: command.new_id.clone(),
+                })
+                .unwrap_or_else(|| BranchTip {
+                    base_branch: "main".to_string(),
+                    from_hash: String::new(),
+                    to_hash: String::new(),
+                });
+            let res = MonoRepo {
                 git_object_cache: state.git_object_cache.clone(),
                 storage: state.storage.clone(),
                 path: self.repo_path.clone(),
-                base_branch: "main".to_string(),
-                from_hash: String::new(),
-                to_hash: String::new(),
+                tip: Mutex::new(tip),
                 current_commit: Arc::new(RwLock::new(None)),
                 cl_link: Arc::new(RwLock::new(None)),
                 application: state.application.clone(),
                 username: self.auth.username.clone(),
                 command_list: Mutex::new(commands.clone()),
             };
-            // Metadata must describe a surviving change: a deletion's zero
-            // new_id would otherwise flow into finalize events even when the
-            // deletion itself is rejected and other updates land.
-            if let Some(command) = commands
-                .iter()
-                .find(|x| x.ref_type == RefTypeEnum::Branch && x.command_type != CommandType::Delete)
-            {
-                res.from_hash = command.old_id.clone();
-                res.to_hash = command.new_id.clone();
-                res.base_branch = command
-                    .ref_name
-                    .strip_prefix("refs/heads/")
-                    .unwrap_or(command.ref_name.as_str())
-                    .to_string();
-            }
             Ok(Arc::new(res) as Arc<dyn RepoHandler>)
         }
     }

--- a/ceres/src/transport/protocol/smart.rs
+++ b/ceres/src/transport/protocol/smart.rs
@@ -245,6 +245,7 @@ impl SmartSession {
         // front instead of failing later with opaque errors or silently
         // writing unrelated refs. Import repos handle their own deletions.
         if is_monorepo {
+            let mut surviving_branch_update = false;
             for command in commands.iter_mut() {
                 if command.command_type == CommandType::Delete {
                     command.failed(format!(
@@ -257,25 +258,38 @@ impl SmartSession {
                          manage tags through the tag API"
                             .to_string(),
                     );
+                } else if command.status == "ok" {
+                    // Each push materializes a single CL from one branch tip;
+                    // multiple updates would overwrite each other's CL ref
+                    // while all reporting success. (Packed pushes hit the same
+                    // restriction in check_entry.)
+                    if surviving_branch_update {
+                        command.failed(
+                            "monorepo pushes support at most one branch update".to_string(),
+                        );
+                    } else {
+                        surviving_branch_update = true;
+                    }
                 }
             }
         }
-        // A pack-less push carries no objects, so any surviving branch command
-        // must target a commit the server already stores; real git clients
-        // never send otherwise ("everything up-to-date" sends no request at
-        // all). Fail such commands here rather than letting finalization trip
-        // over the missing object later. Tags are exempt: their new id may be
-        // an annotated tag object, which the commit table does not track.
+        // A pack-less push carries no objects, so every surviving non-deletion
+        // command must target an object the server already stores; real git
+        // clients never send otherwise ("everything up-to-date" sends no
+        // request at all). Branches resolve against commits, annotated tags
+        // against stored tag objects. Fail unverifiable commands here rather
+        // than persisting dangling refs or tripping finalization later.
         if pack_stream.is_none() {
             for command in commands.iter_mut() {
-                if command.status == "ok"
-                    && command.ref_type == RefTypeEnum::Branch
-                    && command.command_type != CommandType::Delete
-                {
-                    let exists = repo_handler.check_commit_exist(&command.new_id).await;
-                    if !exists {
-                        command.failed(format!("target object {} not found", command.new_id));
-                    }
+                if command.status != "ok" || command.command_type == CommandType::Delete {
+                    continue;
+                }
+                let exists = match command.ref_type {
+                    RefTypeEnum::Tag => repo_handler.check_tag_exist(&command.new_id).await,
+                    _ => repo_handler.check_commit_exist(&command.new_id).await,
+                };
+                if !exists {
+                    command.failed(format!("target object {} not found", command.new_id));
                 }
             }
         }

--- a/ceres/src/transport/protocol/smart.rs
+++ b/ceres/src/transport/protocol/smart.rs
@@ -15,7 +15,7 @@ use crate::{
         pack::PackByteStream,
         protocol::{
             Capability, ServiceType, SideBind, SmartSession, TransportProtocol, ZERO_ID,
-            import_refs::RefCommand,
+            import_refs::{CommandType, RefCommand},
         },
     },
 };
@@ -238,6 +238,23 @@ impl SmartSession {
             .repo_handler_with_commands(state, commands.clone())
             .await?;
         let is_monorepo = repo_handler.is_monorepo();
+        // A deletion's new id is the zero id and monorepo branch state only
+        // advances through CL merges, so there is no commit to materialize a
+        // ref update from. Reject such commands up front (import repos do
+        // support deletion) instead of failing later inside finalize with an
+        // opaque zero-id lookup error.
+        if is_monorepo {
+            for command in commands.iter_mut() {
+                if command.ref_type == RefTypeEnum::Branch
+                    && command.command_type == CommandType::Delete
+                {
+                    command.failed(format!(
+                        "deleting {} is not supported on monorepo",
+                        command.ref_name
+                    ));
+                }
+            }
+        }
         // 1. unpack progress. Pack-less pushes (e.g. ref deletions) carry no packfile
         //    after the command flush, so unpack is skipped entirely.
         let t_unpack = Instant::now();
@@ -309,7 +326,9 @@ impl SmartSession {
 
         let mut finalize_ms: Option<u128> = None;
         let mut bind_ms: Option<u128> = None;
-        if !unpack_failed {
+        // Nothing left to persist when every command was rejected up front
+        // (e.g. a delete-only monorepo push); skip finalize and just report.
+        if !unpack_failed && commands.iter().any(|c| c.status == "ok") {
             let t_finalize = Instant::now();
             if let Err(e) = repo_handler.finalize_receive_pack().await {
                 let msg = e.to_string();

--- a/ceres/src/transport/protocol/smart.rs
+++ b/ceres/src/transport/protocol/smart.rs
@@ -226,7 +226,7 @@ impl SmartSession {
         &mut self,
         state: &TransportRuntime,
         commands: Vec<RefCommand>,
-        data_stream: PackByteStream,
+        pack_stream: Option<PackByteStream>,
     ) -> Result<Bytes, ProtocolError> {
         let t0 = Instant::now();
         let mut timings_ms: BTreeMap<String, u128> = BTreeMap::new();
@@ -238,21 +238,31 @@ impl SmartSession {
             .repo_handler_with_commands(state, commands.clone())
             .await?;
         let is_monorepo = repo_handler.is_monorepo();
-        //1. unpack progress
+        // 1. unpack progress. Pack-less pushes (e.g. ref deletions) carry no packfile
+        //    after the command flush, so unpack is skipped entirely.
         let t_unpack = Instant::now();
-        let receiver = repo_handler
-            .unpack_stream(&state.storage.config().pack, data_stream)
-            .await?;
+        let receiver = match pack_stream {
+            Some(stream) => Some(
+                repo_handler
+                    .unpack_stream(&state.storage.config().pack, stream)
+                    .await?,
+            ),
+            None => None,
+        };
         timings_ms.insert(
             "unpack_stream_ms".to_string(),
             t_unpack.elapsed().as_millis(),
         );
 
         let t_receiver = Instant::now();
-        let unpack_result = repo_handler
-            .clone()
-            .receiver_handler(receiver.0, receiver.1)
-            .await;
+        let unpack_result = if let Some((receiver, rx_pack_id)) = receiver {
+            repo_handler
+                .clone()
+                .receiver_handler(receiver, rx_pack_id)
+                .await
+        } else {
+            Ok(())
+        };
         timings_ms.insert(
             "receiver_handler_ms".to_string(),
             t_receiver.elapsed().as_millis(),

--- a/ceres/src/transport/protocol/smart.rs
+++ b/ceres/src/transport/protocol/smart.rs
@@ -342,15 +342,13 @@ impl SmartSession {
 
         let mut finalize_ms: Option<u128> = None;
         let mut bind_ms: Option<u128> = None;
-        // Skip finalize when nothing survives to finalize: every command
-        // rejected up front (e.g. delete-only monorepo pushes), or a monorepo
-        // push carrying only tag mutations — monorepo finalize events describe
-        // a branch tip and fail against an empty one. Import finalization is
-        // safe without branches (its dispatch returns early) and keeps running.
+        // Skip finalize when no branch command survived validation: rejected
+        // deletions, missing-target updates, or tag-only pushes have no branch
+        // work to finalize, and finalize consumers assume a usable branch tip.
         let has_branch_work = commands
             .iter()
             .any(|c| c.ref_type == RefTypeEnum::Branch && c.status == "ok");
-        if !unpack_failed && (!is_monorepo || has_branch_work) {
+        if !unpack_failed && has_branch_work {
             let t_finalize = Instant::now();
             if let Err(e) = repo_handler.finalize_receive_pack().await {
                 let msg = e.to_string();

--- a/ceres/src/transport/protocol/smart.rs
+++ b/ceres/src/transport/protocol/smart.rs
@@ -327,9 +327,15 @@ impl SmartSession {
 
         let mut finalize_ms: Option<u128> = None;
         let mut bind_ms: Option<u128> = None;
-        // Nothing left to persist when every command was rejected up front
-        // (e.g. a delete-only monorepo push); skip finalize and just report.
-        if !unpack_failed && commands.iter().any(|c| c.status == "ok") {
+        // Skip finalize when nothing survives to finalize: every command
+        // rejected up front (e.g. delete-only monorepo pushes), or a monorepo
+        // push carrying only tag mutations — monorepo finalize events describe
+        // a branch tip and fail against an empty one. Import finalization is
+        // safe without branches (its dispatch returns early) and keeps running.
+        let has_branch_work = commands
+            .iter()
+            .any(|c| c.ref_type == RefTypeEnum::Branch && c.status == "ok");
+        if !unpack_failed && (!is_monorepo || has_branch_work) {
             let t_finalize = Instant::now();
             if let Err(e) = repo_handler.finalize_receive_pack().await {
                 let msg = e.to_string();

--- a/ceres/src/transport/protocol/smart.rs
+++ b/ceres/src/transport/protocol/smart.rs
@@ -245,7 +245,6 @@ impl SmartSession {
         // front instead of failing later with opaque errors or silently
         // writing unrelated refs. Import repos handle their own deletions.
         if is_monorepo {
-            let mut surviving_branch_update = false;
             for command in commands.iter_mut() {
                 if command.command_type == CommandType::Delete {
                     command.failed(format!(
@@ -258,11 +257,37 @@ impl SmartSession {
                          manage tags through the tag API"
                             .to_string(),
                     );
-                } else if command.status == "ok" {
-                    // Each push materializes a single CL from one branch tip;
-                    // multiple updates would overwrite each other's CL ref
-                    // while all reporting success. (Packed pushes hit the same
-                    // restriction in check_entry.)
+                }
+            }
+        }
+        // A pack-less push carries no objects, so every surviving non-deletion
+        // command must target an object the server already stores; real git
+        // clients never send otherwise ("everything up-to-date" sends no
+        // request at all). Tags may reference any stored object type; branches
+        // must point at a commit. Fail unverifiable commands here rather than
+        // persisting dangling refs or tripping finalization later.
+        if pack_stream.is_none() {
+            for command in commands.iter_mut() {
+                if command.status != "ok" || command.command_type == CommandType::Delete {
+                    continue;
+                }
+                let exists = match command.ref_type {
+                    RefTypeEnum::Branch => repo_handler.check_commit_exist(&command.new_id).await,
+                    _ => repo_handler.check_object_exist(&command.new_id).await,
+                };
+                if !exists {
+                    command.failed(format!("target object {} not found", command.new_id));
+                }
+            }
+        }
+        // Each monorepo push materializes a single CL from one branch tip;
+        // multiple updates would overwrite each other's CL ref while all
+        // reporting success. Count only commands that survived validation.
+        // (Packed pushes hit the same restriction in check_entry.)
+        if is_monorepo {
+            let mut surviving_branch_update = false;
+            for command in commands.iter_mut() {
+                if command.ref_type == RefTypeEnum::Branch && command.status == "ok" {
                     if surviving_branch_update {
                         command.failed(
                             "monorepo pushes support at most one branch update".to_string(),
@@ -270,26 +295,6 @@ impl SmartSession {
                     } else {
                         surviving_branch_update = true;
                     }
-                }
-            }
-        }
-        // A pack-less push carries no objects, so every surviving non-deletion
-        // command must target an object the server already stores; real git
-        // clients never send otherwise ("everything up-to-date" sends no
-        // request at all). Branches resolve against commits, annotated tags
-        // against stored tag objects. Fail unverifiable commands here rather
-        // than persisting dangling refs or tripping finalization later.
-        if pack_stream.is_none() {
-            for command in commands.iter_mut() {
-                if command.status != "ok" || command.command_type == CommandType::Delete {
-                    continue;
-                }
-                let exists = match command.ref_type {
-                    RefTypeEnum::Tag => repo_handler.check_tag_exist(&command.new_id).await,
-                    _ => repo_handler.check_commit_exist(&command.new_id).await,
-                };
-                if !exists {
-                    command.failed(format!("target object {} not found", command.new_id));
                 }
             }
         }

--- a/ceres/src/transport/protocol/smart.rs
+++ b/ceres/src/transport/protocol/smart.rs
@@ -238,16 +238,13 @@ impl SmartSession {
             .repo_handler_with_commands(state, commands.clone())
             .await?;
         let is_monorepo = repo_handler.is_monorepo();
-        // A deletion's new id is the zero id and monorepo branch state only
-        // advances through CL merges, so there is no commit to materialize a
-        // ref update from. Reject such commands up front (import repos do
-        // support deletion) instead of failing later inside finalize with an
-        // opaque zero-id lookup error.
+        // A deletion's new id is the zero id and monorepo state only advances
+        // through CL merges, so there is no commit to materialize a ref update
+        // from. Reject such commands up front (import repos do support
+        // deletion) instead of failing later with opaque zero-id lookup errors.
         if is_monorepo {
             for command in commands.iter_mut() {
-                if command.ref_type == RefTypeEnum::Branch
-                    && command.command_type == CommandType::Delete
-                {
+                if command.command_type == CommandType::Delete {
                     command.failed(format!(
                         "deleting {} is not supported on monorepo",
                         command.ref_name
@@ -296,7 +293,11 @@ impl SmartSession {
         //    mono and import both persist branch refs inside `finalize_receive_pack`.
         for command in commands.iter_mut() {
             if command.ref_type == RefTypeEnum::Tag {
-                // just update if refs type is tag
+                // Already-rejected commands (e.g. monorepo deletions) keep
+                // their up-front failure reason instead of being re-processed.
+                if command.status != "ok" {
+                    continue;
+                }
                 if let Err(e) = repo_handler.update_refs(command).await {
                     command.failed(e.to_string());
                 }

--- a/ceres/src/transport/protocol/smart.rs
+++ b/ceres/src/transport/protocol/smart.rs
@@ -252,6 +252,21 @@ impl SmartSession {
                 }
             }
         }
+        // A pack-less push carries no objects, so any surviving non-deletion
+        // command must target an object the server already stores; real git
+        // clients never send otherwise ("everything up-to-date" sends no
+        // request at all). Fail such commands here rather than letting
+        // finalization trip over the missing object later.
+        if pack_stream.is_none() {
+            for command in commands.iter_mut() {
+                if command.command_type != CommandType::Delete && command.status == "ok" {
+                    let exists = repo_handler.check_commit_exist(&command.new_id).await;
+                    if !exists {
+                        command.failed(format!("target object {} not found", command.new_id));
+                    }
+                }
+            }
+        }
         // 1. unpack progress. Pack-less pushes (e.g. ref deletions) carry no packfile
         //    after the command flush, so unpack is skipped entirely.
         let t_unpack = Instant::now();

--- a/ceres/src/transport/protocol/smart.rs
+++ b/ceres/src/transport/protocol/smart.rs
@@ -238,10 +238,12 @@ impl SmartSession {
             .repo_handler_with_commands(state, commands.clone())
             .await?;
         let is_monorepo = repo_handler.is_monorepo();
-        // A deletion's new id is the zero id and monorepo state only advances
-        // through CL merges, so there is no commit to materialize a ref update
-        // from. Reject such commands up front (import repos do support
-        // deletion) instead of failing later with opaque zero-id lookup errors.
+        // Monorepo state advances only through CL merges: a deletion's new id
+        // is the zero id and resolves no commit to materialize a ref update
+        // from, and tag refs are managed through the tag API rather than
+        // receive-pack (pushed tags were never persisted here). Reject both up
+        // front instead of failing later with opaque errors or silently
+        // writing unrelated refs. Import repos handle their own deletions.
         if is_monorepo {
             for command in commands.iter_mut() {
                 if command.command_type == CommandType::Delete {
@@ -249,17 +251,27 @@ impl SmartSession {
                         "deleting {} is not supported on monorepo",
                         command.ref_name
                     ));
+                } else if command.ref_type == RefTypeEnum::Tag {
+                    command.failed(
+                        "tag pushes are not supported on monorepo; \
+                         manage tags through the tag API"
+                            .to_string(),
+                    );
                 }
             }
         }
-        // A pack-less push carries no objects, so any surviving non-deletion
-        // command must target an object the server already stores; real git
-        // clients never send otherwise ("everything up-to-date" sends no
-        // request at all). Fail such commands here rather than letting
-        // finalization trip over the missing object later.
+        // A pack-less push carries no objects, so any surviving branch command
+        // must target a commit the server already stores; real git clients
+        // never send otherwise ("everything up-to-date" sends no request at
+        // all). Fail such commands here rather than letting finalization trip
+        // over the missing object later. Tags are exempt: their new id may be
+        // an annotated tag object, which the commit table does not track.
         if pack_stream.is_none() {
             for command in commands.iter_mut() {
-                if command.command_type != CommandType::Delete && command.status == "ok" {
+                if command.status == "ok"
+                    && command.ref_type == RefTypeEnum::Branch
+                    && command.command_type != CommandType::Delete
+                {
                     let exists = repo_handler.check_commit_exist(&command.new_id).await;
                     if !exists {
                         command.failed(format!("target object {} not found", command.new_id));

--- a/jupiter/src/storage/git_db_storage.rs
+++ b/jupiter/src/storage/git_db_storage.rs
@@ -168,6 +168,20 @@ impl GitDbStorage {
         Ok(())
     }
 
+    pub async fn get_ref_by_name_in_txn(
+        &self,
+        repo_id: i64,
+        ref_name: &str,
+        txn: &DatabaseTransaction,
+    ) -> Result<Option<import_refs::Model>, MegaError> {
+        let result = import_refs::Entity::find()
+            .filter(import_refs::Column::RepoId.eq(repo_id))
+            .filter(import_refs::Column::RefName.eq(ref_name))
+            .one(txn)
+            .await?;
+        Ok(result)
+    }
+
     pub async fn update_ref_in_txn(
         &self,
         repo_id: i64,

--- a/jupiter/src/storage/git_db_storage.rs
+++ b/jupiter/src/storage/git_db_storage.rs
@@ -13,9 +13,9 @@ use common::{
 };
 use futures::Stream;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DatabaseTransaction, DbBackend, DbErr, EntityTrait,
-    IntoActiveModel, PaginatorTrait, QueryFilter, QueryOrder, QueryTrait, Set, TransactionTrait,
-    sea_query::Expr,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseTransaction, DbBackend, DbErr,
+    EntityTrait, IntoActiveModel, PaginatorTrait, QueryFilter, QueryOrder, QueryTrait, Set,
+    TransactionTrait, sea_query::Expr,
 };
 
 use crate::storage::base_storage::{BaseStorage, StorageConnector};
@@ -168,18 +168,23 @@ impl GitDbStorage {
         Ok(())
     }
 
-    pub async fn get_ref_by_name_in_txn(
+    /// Deletes the ref only if it still points at `expected_git_id`, reporting
+    /// whether a row was removed. Enforces receive-pack's advertised-old-id
+    /// lease atomically: a concurrent push that moved the ref leaves it intact.
+    pub async fn remove_ref_if_unchanged<C: ConnectionTrait>(
         &self,
         repo_id: i64,
         ref_name: &str,
-        txn: &DatabaseTransaction,
-    ) -> Result<Option<import_refs::Model>, MegaError> {
-        let result = import_refs::Entity::find()
+        expected_git_id: &str,
+        conn: &C,
+    ) -> Result<bool, MegaError> {
+        let result = import_refs::Entity::delete_many()
             .filter(import_refs::Column::RepoId.eq(repo_id))
             .filter(import_refs::Column::RefName.eq(ref_name))
-            .one(txn)
+            .filter(import_refs::Column::RefGitId.eq(expected_git_id))
+            .exec(conn)
             .await?;
-        Ok(result)
+        Ok(result.rows_affected > 0)
     }
 
     pub async fn update_ref_in_txn(

--- a/jupiter/src/storage/git_db_storage.rs
+++ b/jupiter/src/storage/git_db_storage.rs
@@ -535,9 +535,22 @@ impl GitDbStorage {
             .map(|m| (m, num_items))?)
     }
 
-    /// Find single tag by repo id and tag name
-    pub async fn get_tag_by_repo_and_name(
+    /// Find a stored annotated tag object by its object id.
+    pub async fn get_tag_by_hash(
         &self,
+        repo_id: i64,
+        tag_id: &str,
+    ) -> Result<Option<git_tag::Model>, MegaError> {
+        let result = git_tag::Entity::find()
+            .filter(git_tag::Column::RepoId.eq(repo_id))
+            .filter(git_tag::Column::TagId.eq(tag_id.to_string()))
+            .one(self.get_connection())
+            .await?;
+        Ok(result)
+    }
+
+    /// Find single tag by repo id and tag name
+    pub async fn get_tag_by_repo_and_name(        &self,
         repo_id: i64,
         name: &str,
     ) -> Result<Option<git_tag::Model>, MegaError> {

--- a/mono/src/git_protocol/http.rs
+++ b/mono/src/git_protocol/http.rs
@@ -2,15 +2,17 @@ use std::convert::Infallible;
 
 use anyhow::Result;
 use axum::{
-    body::Body,
+    body::{Body, BodyDataStream},
     http::{HeaderValue, Request, Response},
 };
 use base64::Engine;
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 use ceres::{
     TransportRuntime,
     infra::pack_stream::into_pack_byte_stream,
-    transport::protocol::{PushUserInfo, ServiceType, SmartSession, TransportProtocol, smart},
+    transport::protocol::{
+        PushUserInfo, ServiceType, SmartSession, TransportProtocol, import_refs::RefCommand, smart,
+    },
 };
 use common::errors::{ProtocolError, mega_to_protocol_error};
 use futures::{TryStreamExt, stream};
@@ -256,30 +258,9 @@ pub async fn git_receive_pack(
     if !git_receive_pack_auth(state, &mut pack_protocol, req.headers()).await? {
         return auth_failed();
     }
-    // Convert the request body into a data stream.
-    let mut data_stream = req.into_body().into_data_stream();
-    let mut report_status = Bytes::new();
+    let data_stream = req.into_body().into_data_stream();
+    let report_status = process_receive_pack_body(state, &mut pack_protocol, data_stream).await?;
 
-    let mut chunk_buffer = BytesMut::new(); // Used to cache the data of chunks before the PACK subsequence is found.
-    // Process the data stream to handle the Git receive-pack protocol.
-    while let Some(chunk) = data_stream.next().await {
-        let chunk = chunk.unwrap();
-        // Process the data up to the "PACK" subsequence.
-        if let Some(pos) = search_subsequence(&chunk, b"PACK") {
-            chunk_buffer.extend_from_slice(&chunk[0..pos]);
-            let commands =
-                pack_protocol.parse_receive_pack_commands(Bytes::copy_from_slice(&chunk_buffer));
-            // Create a new stream from the remaining bytes and the rest of the data stream.
-            let left_chunk_bytes = Bytes::copy_from_slice(&chunk[pos..]);
-            let pack_stream = stream::once(async { Ok(left_chunk_bytes) }).chain(data_stream);
-            report_status = pack_protocol
-                .git_receive_pack_stream(state, commands, into_pack_byte_stream(pack_stream))
-                .await?;
-            break;
-        } else {
-            chunk_buffer.extend_from_slice(&chunk);
-        }
-    }
     tracing::info!("report status:{:?}", report_status);
     let response = Response::builder().body(Body::from(report_status)).unwrap();
     let response = add_default_header(
@@ -289,9 +270,88 @@ pub async fn git_receive_pack(
     Ok(response)
 }
 
-// Function to find the subsequence in a slice
-pub fn search_subsequence(chunk: &[u8], search: &[u8]) -> Option<usize> {
-    chunk.windows(search.len()).position(|s| s == search)
+/// Consumes the receive-pack request body and processes the push it carries.
+///
+/// The body is framed by pkt-line structure instead of searching for the `PACK`
+/// magic: the command section ends at a flush packet (`0000`) and the packfile,
+/// when present, starts right after it. Scanning raw bytes for `PACK` breaks when
+/// the signature straddles a transport chunk boundary or when a push carries no
+/// packfile at all (e.g. ref deletions).
+async fn process_receive_pack_body(
+    state: &TransportRuntime,
+    pack_protocol: &mut SmartSession,
+    mut data_stream: BodyDataStream,
+) -> Result<Bytes, ProtocolError> {
+    let mut chunk_buffer = BytesMut::new();
+    // `Some` once the flush-terminated command section has been parsed; the buffered
+    // bytes that follow are packfile data.
+    let mut commands: Option<Vec<RefCommand>> = None;
+    while let Some(chunk) = data_stream.next().await {
+        chunk_buffer.extend_from_slice(&chunk.unwrap());
+        if commands.is_none()
+            && let Some((commands_bytes, pack_head)) = split_commands_and_pack(&mut chunk_buffer)?
+        {
+            commands = Some(pack_protocol.parse_receive_pack_commands(commands_bytes));
+            chunk_buffer = pack_head.into();
+        }
+        if commands.is_some() && !chunk_buffer.is_empty() {
+            let commands = commands.take().unwrap_or_default();
+            let pack_head = std::mem::take(&mut chunk_buffer).freeze();
+            let pack_stream = stream::once(async move { Ok(pack_head) }).chain(data_stream);
+            return pack_protocol
+                .git_receive_pack_stream(state, commands, Some(into_pack_byte_stream(pack_stream)))
+                .await;
+        }
+    }
+
+    if let Some(commands) = commands {
+        // The stream ended right after the flush: a pack-less push.
+        return pack_protocol
+            .git_receive_pack_stream(state, commands, None)
+            .await;
+    }
+    Err(ProtocolError::InvalidInput(
+        "receive-pack body ended before the pkt-line flush".to_string(),
+    ))
+}
+
+/// Splits a buffered receive-pack body into its command section and the start of the
+/// packfile by walking pkt-line framing.
+///
+/// Returns `Ok(None)` while more bytes are needed to reach the terminating flush
+/// packet, and an error on malformed length headers.
+pub(crate) fn split_commands_and_pack(
+    buffer: &mut BytesMut,
+) -> Result<Option<(Bytes, Bytes)>, ProtocolError> {
+    let mut consumed = 0;
+    loop {
+        if buffer.len() < consumed + 4 {
+            return Ok(None);
+        }
+        let len = std::str::from_utf8(&buffer[consumed..consumed + 4])
+            .map_err(|_| {
+                ProtocolError::InvalidInput("pkt-line length header is not UTF-8".to_string())
+            })
+            .and_then(|header| {
+                usize::from_str_radix(header, 16).map_err(|_| {
+                    ProtocolError::InvalidInput(format!("invalid pkt-line length: {header}"))
+                })
+            })?;
+        if len == 0 {
+            let commands = buffer.split_to(consumed).freeze();
+            buffer.advance(4);
+            return Ok(Some((commands, buffer.split().freeze())));
+        }
+        if len < 4 {
+            return Err(ProtocolError::InvalidInput(format!(
+                "invalid pkt-line length: {len}"
+            )));
+        }
+        if buffer.len() < consumed + len {
+            return Ok(None);
+        }
+        consumed += len;
+    }
 }
 
 /// # Build Response headers for Smart Server.
@@ -310,4 +370,82 @@ fn add_default_header<T>(content_type: String, mut response: Response<T>) -> Res
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::*;
+
+    fn pkt_line(payload: &[u8]) -> Vec<u8> {
+        let mut line = format!("{:04x}", payload.len() + 4).into_bytes();
+        line.extend_from_slice(payload);
+        line
+    }
+
+    fn command_section() -> Vec<u8> {
+        let mut body = pkt_line(
+            b"0000000000000000000000000000000000000000 27dd8d4cf39f3868c6eee38b601bc9e9939304f5 refs/heads/main\0report-status\n",
+        );
+        body.extend_from_slice(&pkt_line(
+            b"27dd8d4cf39f3868c6eee38b601bc9e9939304f5 0000000000000000000000000000000000000000 refs/heads/PACK\0\n",
+        ));
+        body.extend_from_slice(b"0000");
+        body
+    }
+
+    #[test]
+    fn split_keeps_commands_before_flush_and_pack_after() {
+        let mut buffer = BytesMut::from_iter(command_section());
+        buffer.extend_from_slice(b"PACK....");
+
+        let (commands, pack_head) = split_commands_and_pack(&mut buffer)
+            .unwrap()
+            .expect("flush packet present");
+        let expected_commands = &command_section()[..command_section().len() - 4];
+        assert_eq!(&commands[..], expected_commands);
+        assert_eq!(&pack_head[..], b"PACK....");
+        assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn split_handles_flush_marker_straddling_chunks() {
+        let section = command_section();
+        let (first, second) = section.split_at(section.len() - 2);
+
+        let mut buffer = BytesMut::from_iter(first);
+        assert!(split_commands_and_pack(&mut buffer).unwrap().is_none());
+
+        // The flush marker itself straddles the two chunks.
+        buffer.extend_from_slice(second);
+        let (commands, pack_head) = split_commands_and_pack(&mut buffer)
+            .unwrap()
+            .expect("flush completes across chunks");
+        assert_eq!(commands.len(), command_section().len() - 4);
+        assert!(pack_head.is_empty());
+    }
+
+    #[test]
+    fn split_treats_pack_in_ref_name_as_command_data() {
+        let mut buffer = BytesMut::new();
+        buffer.extend_from_slice(&pkt_line(
+            b"0000000000000000000000000000000000000000 27dd8d4cf39f3868c6eee38b601bc9e9939304f5 refs/heads/JDK-PACK\0\n",
+        ));
+        buffer.extend_from_slice(b"0000PACK...");
+
+        let (commands, pack_head) = split_commands_and_pack(&mut buffer)
+            .unwrap()
+            .expect("flush packet present");
+        assert!(
+            std::str::from_utf8(&commands)
+                .unwrap()
+                .contains("refs/heads/JDK-PACK")
+        );
+        assert_eq!(&pack_head[..7], b"PACK...");
+    }
+
+    #[test]
+    fn split_rejects_invalid_length_header() {
+        let mut buffer = BytesMut::from(&b"zzzz"[..]);
+        assert!(split_commands_and_pack(&mut buffer).is_err());
+
+        let mut buffer = BytesMut::from(&b"0002"[..]);
+        assert!(split_commands_and_pack(&mut buffer).is_err());
+    }
+}

--- a/mono/src/git_protocol/ssh.rs
+++ b/mono/src/git_protocol/ssh.rs
@@ -21,7 +21,7 @@ use russh::{
 use tokio::{io::AsyncReadExt, sync::Mutex};
 
 use crate::git_protocol::{
-    http::search_subsequence,
+    http::split_commands_and_pack,
     protocol_error::{ssh_error_message, ssh_exit_status},
 };
 
@@ -264,27 +264,23 @@ impl SshServer {
         session: &mut Session,
     ) -> Result<(), anyhow::Error> {
         let smart_protocol = self.smart_protocol.as_mut().unwrap();
-        let data = self.data_combined.split().freeze();
-        let mut data_stream = Box::pin(stream::once(async move {
-            Ok::<Bytes, std::convert::Infallible>(data)
-        }));
-        let mut report_status = Bytes::new();
+        let mut buffer = std::mem::take(&mut self.data_combined);
 
-        while let Some(chunk) = data_stream.next().await {
-            let chunk = chunk.unwrap();
-
-            if let Some(pos) = search_subsequence(&chunk, b"PACK") {
-                let commands = smart_protocol
-                    .parse_receive_pack_commands(Bytes::copy_from_slice(&chunk[..pos]));
-                let remaining_bytes = Bytes::copy_from_slice(&chunk[pos..]);
-                let remaining_stream =
-                    stream::once(async { Ok(remaining_bytes) }).chain(data_stream);
-                report_status = match smart_protocol
-                    .git_receive_pack_stream(
-                        &self.state,
-                        commands,
-                        into_pack_byte_stream(remaining_stream),
-                    )
+        // Frame by pkt-line structure: commands end at the flush packet and the
+        // packfile (when present) starts right after it. A push without a packfile
+        // (e.g. ref deletion) must still run the receive-pack status report.
+        let report_status = match split_commands_and_pack(&mut buffer)? {
+            Some((commands_bytes, pack_head)) => {
+                let commands = smart_protocol.parse_receive_pack_commands(commands_bytes);
+                let pack_stream = if pack_head.is_empty() {
+                    None
+                } else {
+                    Some(into_pack_byte_stream(stream::once(async move {
+                        Ok::<Bytes, std::io::Error>(pack_head)
+                    })))
+                };
+                match smart_protocol
+                    .git_receive_pack_stream(&self.state, commands, pack_stream)
                     .await
                 {
                     Ok(status) => status,
@@ -292,10 +288,19 @@ impl SshServer {
                         Self::send_protocol_error(session, channel, err)?;
                         return Ok(());
                     }
-                };
-                break;
+                }
             }
-        }
+            None => {
+                Self::send_protocol_error(
+                    session,
+                    channel,
+                    ProtocolError::InvalidInput(
+                        "receive-pack body ended before the pkt-line flush".to_string(),
+                    ),
+                )?;
+                return Ok(());
+            }
+        };
 
         tracing::info!("report status: {:?}", report_status);
         session.data(channel, report_status.to_vec())?;


### PR DESCRIPTION
## Problem

`git_receive_pack` located the start of the packfile by scanning each raw HTTP chunk for the byte sequence `PACK` (`search_subsequence(&chunk, b"PACK")`). That breaks in three ways:

1. **Pack-less pushes are dropped entirely.** A push that carries no packfile — e.g. `git push origin --delete branch`, or a no-op ref update — never contains the `PACK` magic. The read loop drains the body without ever matching, `report_status` stays empty, and the server returns an empty 200 while the pushed commands are never processed. I verified this empirically: capturing the request body of a real `git push --delete main` shows it consists only of pkt-line commands followed by the flush packet, with no `PACK` magic anywhere (178 bytes, `indexOf('PACK') == -1`).
2. **Chunk-boundary straddle.** The 4-byte signature can split across two transport chunks (`…PAC|K…`); searching within individual chunks then never finds it, producing the same silent empty-report failure.
3. **False positive on ref names.** Any ref whose name contains uppercase `PACK` (e.g. `refs/heads/JDK-PACK`) matches mid-command, truncating the command list inside a pkt-line and feeding binary garbage to the unpacker.

The same scan is used by the SSH receive-pack path.

## Fix

Frame the body by protocol structure instead of magic-byte scanning:

- New `split_commands_and_pack` helper walks pkt-line length headers from the accumulated buffer until the terminating flush packet (`0000`) and splits off the command section; everything after the flush is pack data. Malformed length headers now return `ProtocolError::InvalidInput` (HTTP 400) instead of panicking.
- HTTP handler accumulates chunks and processes the push as soon as the flush is framed, chaining any remaining stream onto the pack input — correct regardless of where transport chunk boundaries fall.
- Pushes whose body ends right after the flush are recognized as pack-less pushes: `git_receive_pack_stream` now takes `Option<PackByteStream>` and skips unpack entirely, so ref updates and the status report still run. Previously this path could not be reached at all.
- SSH receive-pack goes through the same helper.
- Removed the now-unused `search_subsequence`.

## Testing

- New unit tests in `mono/src/git_protocol/http.rs` cover: normal framing, flush marker straddling chunk boundaries, `PACK` appearing inside a ref name (must stay command data), and invalid/short length headers being rejected.
- `cargo test -p mono --lib git_protocol` — 4 passed
- `cargo test -p ceres --lib transport` — 10 passed
- `cargo clippy -p mono -p ceres --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --check` clean on all touched files
- Full `cargo test -p ceres --lib`: 160 passed; 9 failures in `application::code_edit` / `application::build_trigger` reproduce identically on unmodified `main` in my environment (unrelated DB-dependent tests)

Signed-off-by: Tyagiquamar <Tyagiquamar@users.noreply.github.com>
